### PR TITLE
requirements for `const-eval`

### DIFF
--- a/design-docs/const-eval-requirements.md
+++ b/design-docs/const-eval-requirements.md
@@ -1,0 +1,14 @@
+# Const eval requirements
+
+For this to work, const operations have to be deterministic and
+must not depend on any external state,
+at least when they are used in the type system.
+
+Using floats during CTFE is fully determinstic. So using
+them inside of the type system is fine. CTFE can however
+produce different results than what would happen on real hardware,
+but this is not a concern for const generics.
+
+Other sources of non-determinism are allocations. This non-determinism
+must however not be observed during const-evaluation (TODO: link to const-eval).
+Any references used in a constant are considered equal if their targets are equal, which is also determistic. (ref [val-trees](https://github.com/rust-lang/rust/issues/72396))


### PR DESCRIPTION
only the second commit is relevant, this is based on top of #1.

@oli-obk @RalfJung can you help me out with the `FIXME`s here?
While I think that we don't have to worry about any of these I also
don't know enough to explain why this is the case.
