### PR TITLE
Fix CI more

### DIFF
--- a/.github/workflows/deploy_mdbook.yml
+++ b/.github/workflows/deploy_mdbook.yml
@@ -1,14 +1,55 @@
+name: mdBook
+
 on:
+  pull_request:
   push:
     branches:
       - master
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  ci:
-    name: CI
+  build:
+    name: Build mdBook
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: XAMPPRocky/deploy-mdbook@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          mdbook-version: latest
+
+      - name: Build book
+        run: mdbook build
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy_mdbook.yml
+++ b/.github/workflows/deploy_mdbook.yml
@@ -22,19 +22,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: latest
+      - uses: Swatinem/rust-cache@v2.9.1
+      - run: cargo install mdbook --version 0.5.2
 
       - name: Build book
         run: mdbook build
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./book
 
@@ -52,4 +50,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
@BoxyUwU  OK, this time it should work. I've changed the action to a more modern one, and tested it in my fork ([it deployed](https://popzxc.github.io/project-const-generics/)).

As a bonus, mdbook will be built on PR too.

One caveat: you should go to the repo settings, and in `GitHub Pages` switch "Source" to "GitHub Actions" for deployments to work.

<img width="626" height="570" alt="image" src="https://github.com/user-attachments/assets/94ec766d-95c4-447c-8d9d-1600e397a6e2" />
